### PR TITLE
Integrate Crispy Fish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <coner-timer.version>0.1.1</coner-timer.version>
         <snoozle.version>0.1.0</snoozle.version>
         <jackson.version>2.9.7</jackson.version>
+        <crispy-fish.version>0.2.0</crispy-fish.version>
     </properties>
 
     <dependencies>
@@ -63,6 +64,11 @@
             <groupId>org.coner</groupId>
             <artifactId>coner-timer-library</artifactId>
             <version>${coner-timer.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.coner</groupId>
+            <artifactId>crispy-fish-library</artifactId>
+            <version>${crispy-fish.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <description>Digital Raw Sheets - reduce the drag of working raw sheets</description>
 
     <properties>
+        <coner-drs.version>${project.version}</coner-drs.version>
         <kotlin.version>1.3.10</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <tornadofx.version>1.7.18-SNAPSHOT</tornadofx.version>
@@ -21,6 +22,8 @@
         <snoozle.version>0.1.0</snoozle.version>
         <jackson.version>2.9.7</jackson.version>
         <crispy-fish.version>0.2.0</crispy-fish.version>
+        <appdirs.version>1.0.2</appdirs.version>
+        <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -70,6 +73,12 @@
             <artifactId>crispy-fish-library</artifactId>
             <version>${crispy-fish.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>net.harawata</groupId>
+            <artifactId>appdirs</artifactId>
+            <version>${appdirs.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -94,6 +103,31 @@
                         <goals> <goal>test-compile</goal> </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>${properties-maven-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-project-properties-into-build</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>write-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>${project.build.outputDirectory}/drs.properties</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.zenjava</groupId>
+                <artifactId>javafx-maven-plugin</artifactId>
+                <version>8.8.3</version>
+                <configuration>
+                    <mainClass>org.coner.drs.DigitalRawSheetAppKt</mainClass>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <rxkotlinfx.version>2.2.2</rxkotlinfx.version>
         <rxfilewatcher.version>1.0.0-SNAPSHOT</rxfilewatcher.version>
         <coner-timer.version>0.1.1</coner-timer.version>
-        <snoozle.version>0.1.1</snoozle.version>
+        <snoozle.version>0.1.2</snoozle.version>
         <jackson.version>2.9.7</jackson.version>
         <crispy-fish.version>0.2.0</crispy-fish.version>
         <appdirs.version>1.0.2</appdirs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,9 @@
         <controlsfx.version>8.40.14</controlsfx.version>
         <tornadofx-controlsfx.version>0.1.1</tornadofx-controlsfx.version>
         <rxkotlinfx.version>2.2.2</rxkotlinfx.version>
+        <rxfilewatcher.version>1.0.0-SNAPSHOT</rxfilewatcher.version>
         <coner-timer.version>0.1.1</coner-timer.version>
-        <snoozle.version>0.1.0</snoozle.version>
+        <snoozle.version>0.1.1</snoozle.version>
         <jackson.version>2.9.7</jackson.version>
         <crispy-fish.version>0.2.0</crispy-fish.version>
         <appdirs.version>1.0.2</appdirs.version>
@@ -57,6 +58,11 @@
             <groupId>org.coner</groupId>
             <artifactId>snoozle</artifactId>
             <version>${snoozle.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>de.helmbold</groupId>
+            <artifactId>rxfilewatcher</artifactId>
+            <version>${rxfilewatcher.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/src/main/kotlin/org/coner/drs/DigitalRawSheetApp.kt
+++ b/src/main/kotlin/org/coner/drs/DigitalRawSheetApp.kt
@@ -1,16 +1,36 @@
 package org.coner.drs
 
+import javafx.application.Application
 import javafx.scene.image.Image
 import javafx.stage.Stage
+import net.harawata.appdirs.AppDirs
+import net.harawata.appdirs.AppDirsFactory
 import org.coner.drs.ui.main.MainView
 import org.coner.style.ConerFxStylesheet
 import tornadofx.*
 import tornadofx.Stylesheet
+import java.net.URI
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.*
 
 class DigitalRawSheetApp : App(
         primaryView = MainView::class,
         stylesheet = org.coner.drs.Stylesheet::class
 ) {
+
+    val drsProperties by lazy {
+        PropertyResourceBundle(resources.url("/drs.properties").openStream())
+    }
+
+    override val configBasePath: Path = Paths.get(URI.create("file://" + AppDirsFactory.getInstance()
+            .getUserConfigDir(
+                    "digital-raw-sheet",
+                    drsProperties.getString("coner-drs.version"),
+                    "coner"
+            )
+    ))
+
     override fun start(stage: Stage) {
         super.start(stage)
         stage.icons.addAll(
@@ -26,6 +46,10 @@ class DigitalRawSheetApp : App(
         stage.minHeight = 768.0
     }
 
+}
+
+fun main(args: Array<String>) {
+    Application.launch(DigitalRawSheetApp::class.java, *args)
 }
 
 class Stylesheet : Stylesheet(ConerFxStylesheet::class) {

--- a/src/main/kotlin/org/coner/drs/UiEntities.kt
+++ b/src/main/kotlin/org/coner/drs/UiEntities.kt
@@ -17,9 +17,9 @@ import java.io.File
 
 class Event(
         id: UUID = UUID.randomUUID(),
-        date: LocalDate,
-        name: String,
-        crispyFishMetadata: CrispyFishMetadata
+        date: LocalDate = LocalDate.now(),
+        name: String = "",
+        crispyFishMetadata: CrispyFishMetadata = CrispyFishMetadata()
 ) {
     val idProperty = SimpleObjectProperty<UUID>(this, "id", id)
     var id by idProperty
@@ -35,14 +35,14 @@ class Event(
     )
     var crispyFishMetadata by crispyFishMetadataProperty
 
-
     val categories = FXCollections.observableSet<String>()
     val handicaps = FXCollections.observableSet<String>()
     val numbers = FXCollections.observableSet<String>()
+    val registrations = FXCollections.observableSet<Registration>()
 
     class CrispyFishMetadata(
-            classDefinitionFile: File,
-            eventControlFile: File
+            classDefinitionFile: File = File(""),
+            eventControlFile: File = File("")
     ) {
         val classDefinitionFileProperty = SimpleObjectProperty<File>(
                 this,
@@ -58,6 +58,40 @@ class Event(
         )
         var eventControlFile by eventControlFileProperty
     }
+}
+
+class EventModel : ItemViewModel<Event>(Event()) {
+    val date = bind(Event::dateProperty, autocommit = true)
+    val name = bind(Event::nameProperty, autocommit = true)
+    val crispyFishMetadata = bind(Event::crispyFishMetadataProperty, autocommit = true)
+}
+
+class Registration(
+        category: String,
+        handicap: String,
+        number: String,
+        name: String,
+        carModel: String,
+        carColor: String
+) {
+    val categoryProperty = SimpleStringProperty(this, "category", category)
+    var category by categoryProperty
+
+    val handicapProperty = SimpleStringProperty(this, "handicap", handicap)
+    var handicap by handicapProperty
+
+    val numberProperty = SimpleStringProperty(this, "number", number)
+    var number by numberProperty
+
+    val nameProperty = SimpleStringProperty(this, "name", name)
+    var name by nameProperty
+
+    val carModelProperty = SimpleStringProperty(this, "carModel", carModel)
+    var carModel by carModelProperty
+
+    val carColorProperty = SimpleStringProperty(this, "carColor", carColor)
+    var carColor by carColorProperty
+
 }
 
 class Run(

--- a/src/main/kotlin/org/coner/drs/UiEntities.kt
+++ b/src/main/kotlin/org/coner/drs/UiEntities.kt
@@ -19,8 +19,7 @@ class Event(
         id: UUID = UUID.randomUUID(),
         date: LocalDate,
         name: String,
-        classDefinitionFile: ClassDefinitionFile,
-        eventControlFile: EventControlFile
+        crispyFishMetadata: CrispyFishMetadata
 ) {
     val idProperty = SimpleObjectProperty<UUID>(this, "id", id)
     var id by idProperty
@@ -31,24 +30,34 @@ class Event(
     val nameProperty = SimpleStringProperty(this, "name", name)
     var name by nameProperty
 
-    val classDefinitionFileProperty = SimpleObjectProperty<ClassDefinitionFile>(
-            this,
-            "classDefinitionFile",
-            classDefinitionFile
+    val crispyFishMetadataProperty = SimpleObjectProperty<CrispyFishMetadata>(
+            this, "crispyFishMetadata", crispyFishMetadata
     )
-    var classDefinitionFile by classDefinitionFileProperty
-
-    val eventControlFileProperty = SimpleObjectProperty<EventControlFile>(
-            this,
-            "eventControlFile",
-            eventControlFile
-    )
-    var eventControlFile by eventControlFileProperty
+    var crispyFishMetadata by crispyFishMetadataProperty
 
 
     val categories = FXCollections.observableSet<String>()
     val handicaps = FXCollections.observableSet<String>()
     val numbers = FXCollections.observableSet<String>()
+
+    class CrispyFishMetadata(
+            classDefinitionFile: File,
+            eventControlFile: File
+    ) {
+        val classDefinitionFileProperty = SimpleObjectProperty<File>(
+                this,
+                "classDefinitionFile",
+                classDefinitionFile
+        )
+        var classDefinitionFile by classDefinitionFileProperty
+
+        val eventControlFileProperty = SimpleObjectProperty<File>(
+                this,
+                "eventControlFile",
+                eventControlFile
+        )
+        var eventControlFile by eventControlFileProperty
+    }
 }
 
 class Run(

--- a/src/main/kotlin/org/coner/drs/UiEntities.kt
+++ b/src/main/kotlin/org/coner/drs/UiEntities.kt
@@ -5,6 +5,8 @@ import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.collections.FXCollections
+import org.coner.crispyfish.filetype.classdefinition.ClassDefinitionFile
+import org.coner.crispyfish.filetype.ecf.EventControlFile
 import tornadofx.*
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -16,7 +18,9 @@ import java.io.File
 class Event(
         id: UUID = UUID.randomUUID(),
         date: LocalDate,
-        name: String
+        name: String,
+        classDefinitionFile: ClassDefinitionFile,
+        eventControlFile: EventControlFile
 ) {
     val idProperty = SimpleObjectProperty<UUID>(this, "id", id)
     var id by idProperty
@@ -26,6 +30,21 @@ class Event(
 
     val nameProperty = SimpleStringProperty(this, "name", name)
     var name by nameProperty
+
+    val classDefinitionFileProperty = SimpleObjectProperty<ClassDefinitionFile>(
+            this,
+            "classDefinitionFile",
+            classDefinitionFile
+    )
+    var classDefinitionFile by classDefinitionFileProperty
+
+    val eventControlFileProperty = SimpleObjectProperty<EventControlFile>(
+            this,
+            "eventControlFile",
+            eventControlFile
+    )
+    var eventControlFile by eventControlFileProperty
+
 
     val categories = FXCollections.observableSet<String>()
     val handicaps = FXCollections.observableSet<String>()

--- a/src/main/kotlin/org/coner/drs/UiEntities.kt
+++ b/src/main/kotlin/org/coner/drs/UiEntities.kt
@@ -5,8 +5,6 @@ import javafx.beans.property.SimpleIntegerProperty
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.collections.FXCollections
-import org.coner.crispyfish.filetype.classdefinition.ClassDefinitionFile
-import org.coner.crispyfish.filetype.ecf.EventControlFile
 import tornadofx.*
 import java.math.BigDecimal
 import java.time.LocalDate
@@ -63,7 +61,11 @@ class Event(
 class EventModel : ItemViewModel<Event>(Event()) {
     val date = bind(Event::dateProperty, autocommit = true)
     val name = bind(Event::nameProperty, autocommit = true)
-    val crispyFishMetadata = bind(Event::crispyFishMetadataProperty, autocommit = true)
+}
+
+class EventCrispyFishMetadataModel : ItemViewModel<Event.CrispyFishMetadata>(Event.CrispyFishMetadata()) {
+    val eventControlFile = bind(Event.CrispyFishMetadata::eventControlFileProperty, autocommit = true)
+    val classDefinitionFile = bind(Event.CrispyFishMetadata::classDefinitionFileProperty, autocommit = true)
 }
 
 class Registration(

--- a/src/main/kotlin/org/coner/drs/UiEntities.kt
+++ b/src/main/kotlin/org/coner/drs/UiEntities.kt
@@ -72,9 +72,9 @@ class Registration(
         category: String,
         handicap: String,
         number: String,
-        name: String,
-        carModel: String,
-        carColor: String
+        name: String? = null,
+        carModel: String? = null,
+        carColor: String? = null
 ) {
     val categoryProperty = SimpleStringProperty(this, "category", category)
     var category by categoryProperty
@@ -100,9 +100,7 @@ class Run(
         id: UUID = UUID.randomUUID(),
         event: Event,
         sequence: Int = 0,
-        category: String = "",
-        handicap: String = "",
-        number: String = "",
+        registration: Registration? = null,
         rawTime: BigDecimal? = null,
         cones: Int = 0,
         didNotFinish: Boolean = false,
@@ -118,14 +116,21 @@ class Run(
     val sequenceProperty = SimpleIntegerProperty(this, "sequence", sequence)
     var sequence by sequenceProperty
 
-    val categoryProperty = SimpleStringProperty(this, "category", category)
-    var category by categoryProperty
+    val registrationProperty = SimpleObjectProperty<Registration>(this, "registration", registration)
+    var registration by registrationProperty
 
-    val handicapProperty = SimpleStringProperty(this, "handicap", handicap)
-    var handicap by handicapProperty
+    val registrationCategoryProperty = registrationProperty.select(Registration::categoryProperty)
+    val registrationCategory by registrationCategoryProperty
 
-    val numberProperty = SimpleStringProperty(this, "number", number)
-    var number by numberProperty
+    val registrationHandicapProperty = registrationProperty.select(Registration::handicapProperty)
+    val registrationHandicap by registrationHandicapProperty
+
+    val registrationNumberProperty = registrationProperty.select(Registration::numberProperty)
+    val registrationNumber by registrationNumberProperty
+
+    val registrationDriverNameProperty = registrationProperty.select(Registration::nameProperty)
+    val registrationCarModelProperty = registrationProperty.select(Registration::carModelProperty)
+    val registrationCarColorProperty = registrationProperty.select(Registration::carColorProperty)
 
     val rawTimeProperty = SimpleObjectProperty<BigDecimal>(this, "rawTime", rawTime)
     var rawTime by rawTimeProperty
@@ -147,9 +152,7 @@ class Run(
 class NextDriverModel : ItemViewModel<Run>() {
     val event = bind(Run::eventProperty)
     val sequence = bind(Run::sequenceProperty)
-    val category = bind(Run::categoryProperty)
-    val handicap = bind(Run::handicapProperty)
-    val number = bind(Run::numberProperty)
+    val registration = bind(Run::registrationProperty)
 }
 
 sealed class TimerConfiguration {

--- a/src/main/kotlin/org/coner/drs/io/DrsIo.kt
+++ b/src/main/kotlin/org/coner/drs/io/DrsIo.kt
@@ -19,7 +19,6 @@ class DrsIoController : Controller() {
         model.pathToDrsDatabase = pathToDrsDatabase
         model.pathToCrispyFishDatabase = pathToCrispyFishDatabase
         createDrsDbPath()
-        createDrsDbEventsPath()
         model.db = Database(
                 root = pathToDrsDatabase,
                 objectMapper = jacksonObjectMapper()
@@ -35,30 +34,9 @@ class DrsIoController : Controller() {
     }
 
     fun createDrsDbPath() {
-        // TODO: Snoozle should auto-create these
         val pathToDrsDbPath = model.pathToDrsDatabase?.toPath()
         if (Files.notExists(pathToDrsDbPath)) {
             Files.createDirectories(pathToDrsDbPath)
-        }
-    }
-
-    fun createDrsDbEventsPath() {
-        // TODO: Snoozle should auto-create these
-        val pathToEvents = model.pathToDrsDatabase?.toPath()
-                ?.resolve("events")
-        if (Files.notExists(pathToEvents)) {
-            Files.createDirectories(pathToEvents)
-        }
-    }
-
-    fun createDrsDbRunsPath(event: Event) {
-        // TODO: Snoozle should auto-create these
-        val pathToRuns = model.pathToDrsDatabase?.toPath()
-                ?.resolve("events")
-                ?.resolve(event.id.toString())
-                ?.resolve("runs")
-        if (Files.notExists(pathToRuns)) {
-            Files.createDirectories(pathToRuns)
         }
     }
 

--- a/src/main/kotlin/org/coner/drs/io/DrsIo.kt
+++ b/src/main/kotlin/org/coner/drs/io/DrsIo.kt
@@ -62,8 +62,16 @@ class DrsIoController : Controller() {
         }
     }
 
-    fun isInsideCrispyFishDatabase(file: File): Boolean {
-        return file.startsWith(model.pathToCrispyFishDatabase!!)
+    fun isInsideCrispyFishDatabase(file: File, recursion: Int = 0): Boolean {
+        check(recursion <= 1) { "Recursion exceeded maximum of 1" }
+        if (file.isAbsolute) {
+            return file.canonicalFile.startsWith(model.pathToCrispyFishDatabase!!)
+        } else {
+            return isInsideCrispyFishDatabase(
+                    model.pathToCrispyFishDatabase!!.resolve(file),
+                    recursion + 1
+            )
+        }
     }
 
     fun close() {

--- a/src/main/kotlin/org/coner/drs/io/DrsIo.kt
+++ b/src/main/kotlin/org/coner/drs/io/DrsIo.kt
@@ -14,9 +14,10 @@ import java.nio.file.Files
 class DrsIoController : Controller() {
     val model: DrsIoModel by inject()
 
-    fun open(pathToDrsDatabase: File) {
+    fun open(pathToDrsDatabase: File, pathToCrispyFishDatabase: File) {
         if (model.db != null) throw IllegalStateException("Database is already open")
         model.pathToDrsDatabase = pathToDrsDatabase
+        model.pathToCrispyFishDatabase = pathToCrispyFishDatabase
         createDrsDbPath()
         createDrsDbEventsPath()
         model.db = Database(
@@ -70,5 +71,6 @@ class DrsIoController : Controller() {
 class DrsIoModel : ViewModel() {
     var db: Database? = null
     var pathToDrsDatabase: File? = null
+    var pathToCrispyFishDatabase: File? = null
     val open: Boolean get() = db != null
 }

--- a/src/main/kotlin/org/coner/drs/io/DrsIo.kt
+++ b/src/main/kotlin/org/coner/drs/io/DrsIo.kt
@@ -62,6 +62,10 @@ class DrsIoController : Controller() {
         }
     }
 
+    fun isInsideCrispyFishDatabase(file: File): Boolean {
+        return file.startsWith(model.pathToCrispyFishDatabase!!)
+    }
+
     fun close() {
         model.db = null
         model.pathToDrsDatabase = null

--- a/src/main/kotlin/org/coner/drs/io/crispyfish/Extensions.kt
+++ b/src/main/kotlin/org/coner/drs/io/crispyfish/Extensions.kt
@@ -1,0 +1,12 @@
+package org.coner.drs.io.crispyfish
+
+import org.coner.crispyfish.filetype.classdefinition.ClassDefinitionFile
+import org.coner.crispyfish.filetype.ecf.EventControlFile
+import org.coner.drs.Event
+
+fun Event.buildEventControlFile() = EventControlFile(
+        file = crispyFishMetadata.eventControlFile,
+        classDefinitionFile = ClassDefinitionFile(crispyFishMetadata.classDefinitionFile),
+        conePenalty = 2, // TODO: implement default value 2
+        isTwoDayEvent = false // TODO: implement default value false
+)

--- a/src/main/kotlin/org/coner/drs/io/crispyfish/RegistrationMapper.kt
+++ b/src/main/kotlin/org/coner/drs/io/crispyfish/RegistrationMapper.kt
@@ -1,0 +1,17 @@
+package org.coner.drs.io.crispyfish
+
+import org.coner.crispyfish.model.Registration
+
+object RegistrationMapper {
+
+    fun toUiEntity(crispyFishEntity: Registration) = with(crispyFishEntity) {
+        org.coner.drs.Registration(
+                category = category?.abbreviation ?: "",
+                handicap = handicap.abbreviation,
+                number = number,
+                name = "$firstName $lastName",
+                carModel = carModel,
+                carColor = carColor
+        )
+    }
+}

--- a/src/main/kotlin/org/coner/drs/io/db/entity/EventDbEntity.kt
+++ b/src/main/kotlin/org/coner/drs/io/db/entity/EventDbEntity.kt
@@ -1,8 +1,11 @@
 package org.coner.drs.io.db.entity
 
+import javafx.beans.value.ObservableValue
 import org.coner.drs.Event
+import org.coner.drs.EventModel
 import org.coner.snoozle.db.Entity
 import org.coner.snoozle.db.EntityPath
+import tornadofx.*
 import java.io.File
 import java.time.LocalDate
 import java.util.*
@@ -49,5 +52,4 @@ class EventDbEntityMapper(
                 )
             }
         )
-
 }

--- a/src/main/kotlin/org/coner/drs/io/db/entity/EventDbEntity.kt
+++ b/src/main/kotlin/org/coner/drs/io/db/entity/EventDbEntity.kt
@@ -1,8 +1,11 @@
 package org.coner.drs.io.db.entity
 
+import org.coner.crispyfish.filetype.classdefinition.ClassDefinitionFile
+import org.coner.crispyfish.filetype.ecf.EventControlFile
 import org.coner.drs.Event
 import org.coner.snoozle.db.Entity
 import org.coner.snoozle.db.EntityPath
+import java.io.File
 import java.time.LocalDate
 import java.util.*
 
@@ -10,21 +13,39 @@ import java.util.*
 data class EventDbEntity(
         val id: UUID = UUID.randomUUID(),
         val date: LocalDate,
-        val name: String
+        val name: String,
+        val crispyFishClassDefinitionFile: String,
+        val crispyFishEventControlFile: String
 ) : Entity
 
-object EventDbEntityMapper {
+class EventDbEntityMapper(
+        val crispyFishDatabase: File
+) {
 
-    fun toUiEntity(dbEntity: EventDbEntity?) = if (dbEntity != null) Event(
-            id = dbEntity.id,
-            date = dbEntity.date,
-            name = dbEntity.name
-    ) else null
+    fun toUiEntity(dbEntity: EventDbEntity?) = if (dbEntity != null) {
+        val classDefinitionFile = ClassDefinitionFile(
+                file = crispyFishDatabase.resolve(dbEntity.crispyFishClassDefinitionFile)
+        )
+        Event(
+                id = dbEntity.id,
+                date = dbEntity.date,
+                name = dbEntity.name,
+                classDefinitionFile = classDefinitionFile,
+                eventControlFile = EventControlFile(
+                        file = crispyFishDatabase.resolve(dbEntity.crispyFishEventControlFile),
+                        classDefinitionFile = classDefinitionFile,
+                        conePenalty = 2,
+                        isTwoDayEvent = false
+                )
+        )
+    } else null
 
     fun toDbEntity(uiEntity: Event) = EventDbEntity(
             id = uiEntity.id,
             date = uiEntity.date,
-            name = uiEntity.name
+            name = uiEntity.name,
+            crispyFishClassDefinitionFile = uiEntity.classDefinitionFile.file.toRelativeString(crispyFishDatabase),
+            crispyFishEventControlFile = uiEntity.eventControlFile.file.toRelativeString(crispyFishDatabase)
     )
 
 }

--- a/src/main/kotlin/org/coner/drs/io/db/entity/EventDbEntity.kt
+++ b/src/main/kotlin/org/coner/drs/io/db/entity/EventDbEntity.kt
@@ -1,7 +1,5 @@
 package org.coner.drs.io.db.entity
 
-import org.coner.crispyfish.filetype.classdefinition.ClassDefinitionFile
-import org.coner.crispyfish.filetype.ecf.EventControlFile
 import org.coner.drs.Event
 import org.coner.snoozle.db.Entity
 import org.coner.snoozle.db.EntityPath
@@ -14,38 +12,42 @@ data class EventDbEntity(
         val id: UUID = UUID.randomUUID(),
         val date: LocalDate,
         val name: String,
-        val crispyFishClassDefinitionFile: String,
-        val crispyFishEventControlFile: String
-) : Entity
+        val crispyFishMetadata: CrispyFishMetadata
+
+) : Entity {
+    data class CrispyFishMetadata(
+            val classDefinitionFile: String,
+            val eventControlFile: String
+    )
+}
 
 class EventDbEntityMapper(
         val crispyFishDatabase: File
 ) {
 
-    fun toUiEntity(dbEntity: EventDbEntity?) = if (dbEntity != null) {
-        val classDefinitionFile = ClassDefinitionFile(
-                file = crispyFishDatabase.resolve(dbEntity.crispyFishClassDefinitionFile)
-        )
-        Event(
+    fun toUiEntity(dbEntity: EventDbEntity?) = if (dbEntity != null) Event(
                 id = dbEntity.id,
                 date = dbEntity.date,
                 name = dbEntity.name,
-                classDefinitionFile = classDefinitionFile,
-                eventControlFile = EventControlFile(
-                        file = crispyFishDatabase.resolve(dbEntity.crispyFishEventControlFile),
-                        classDefinitionFile = classDefinitionFile,
-                        conePenalty = 2,
-                        isTwoDayEvent = false
-                )
+                crispyFishMetadata = with(dbEntity.crispyFishMetadata) {
+                    Event.CrispyFishMetadata(
+                            classDefinitionFile = crispyFishDatabase.resolve(classDefinitionFile),
+                            eventControlFile = crispyFishDatabase.resolve(eventControlFile)
+                    )
+                }
         )
-    } else null
+    else null
 
     fun toDbEntity(uiEntity: Event) = EventDbEntity(
             id = uiEntity.id,
             date = uiEntity.date,
             name = uiEntity.name,
-            crispyFishClassDefinitionFile = uiEntity.classDefinitionFile.file.toRelativeString(crispyFishDatabase),
-            crispyFishEventControlFile = uiEntity.eventControlFile.file.toRelativeString(crispyFishDatabase)
-    )
+            crispyFishMetadata = with(uiEntity.crispyFishMetadata) {
+                EventDbEntity.CrispyFishMetadata(
+                        classDefinitionFile = classDefinitionFile.toRelativeString(crispyFishDatabase),
+                        eventControlFile = eventControlFile.toRelativeString(crispyFishDatabase)
+                )
+            }
+        )
 
 }

--- a/src/main/kotlin/org/coner/drs/io/db/entity/RunDbEntity.kt
+++ b/src/main/kotlin/org/coner/drs/io/db/entity/RunDbEntity.kt
@@ -1,6 +1,7 @@
 package org.coner.drs.io.db.entity
 
 import org.coner.drs.Event
+import org.coner.drs.Registration
 import org.coner.drs.Run
 import org.coner.snoozle.db.Entity
 import org.coner.snoozle.db.EntityPath
@@ -27,9 +28,11 @@ object RunDbEntityMapper {
             id = dbEntity.id,
             event = event,
             sequence = dbEntity.sequence,
-            category = dbEntity.category,
-            handicap = dbEntity.handicap,
-            number = dbEntity.number,
+            registration = Registration(
+                    category = dbEntity.category,
+                    handicap = dbEntity.handicap,
+                    number = dbEntity.number
+            ),
             rawTime = dbEntity.rawTime,
             cones = dbEntity.cones,
             didNotFinish = dbEntity.didNotFinish,
@@ -37,17 +40,17 @@ object RunDbEntityMapper {
             rerun = dbEntity.rerun
     ) else null
 
-    fun toDbEntity(uiEntity: Run) = RunDbEntity(
-            id = uiEntity.id,
-            eventId = uiEntity.event.id,
-            sequence = uiEntity.sequence,
-            category = uiEntity.category,
-            handicap = uiEntity.handicap,
-            number = uiEntity.number,
-            rawTime = uiEntity.rawTime,
-            cones = uiEntity.cones,
-            didNotFinish = uiEntity.didNotFinish,
-            disqualified = uiEntity.disqualified,
-            rerun = uiEntity.rerun
+    fun toDbEntity(uiRun: Run) = RunDbEntity(
+            id = uiRun.id,
+            eventId = uiRun.event.id,
+            sequence = uiRun.sequence,
+            category = uiRun.registrationCategory,
+            handicap = uiRun.registrationHandicap,
+            number = uiRun.registrationNumber,
+            rawTime = uiRun.rawTime,
+            cones = uiRun.cones,
+            didNotFinish = uiRun.didNotFinish,
+            disqualified = uiRun.disqualified,
+            rerun = uiRun.rerun
     )
 }

--- a/src/main/kotlin/org/coner/drs/io/db/service/EventService.kt
+++ b/src/main/kotlin/org/coner/drs/io/db/service/EventService.kt
@@ -14,12 +14,13 @@ class EventService : Controller() {
 
     val io: DrsIoController by inject()
     private val db = io.model.db!!
+    val mapper by lazy { EventDbEntityMapper(io.model.pathToCrispyFishDatabase!!) }
 
     fun list(): List<Event> = db.list<EventDbEntity>()
-            .map { EventDbEntityMapper.toUiEntity(it) as Event }
+            .map { mapper.toUiEntity(it) as Event }
 
     fun save(event: Event) {
-        db.put(EventDbEntityMapper.toDbEntity(event))
+        db.put(mapper.toDbEntity(event))
     }
 
     fun watchList(): Observable<EntityWatchEvent<Event>> = db.watchListing<EventDbEntity>()
@@ -27,6 +28,6 @@ class EventService : Controller() {
             .map { EntityWatchEvent(
                     watchEvent = it.watchEvent,
                     id = it.id,
-                    entity = EventDbEntityMapper.toUiEntity(it.entity)
+                    entity = mapper.toUiEntity(it.entity)
             ) }
 }

--- a/src/main/kotlin/org/coner/drs/io/db/service/RunService.kt
+++ b/src/main/kotlin/org/coner/drs/io/db/service/RunService.kt
@@ -18,9 +18,10 @@ class RunService : Controller() {
 
     val io: DrsIoController by inject(FX.defaultScope)
     private val db = io.model.db!!
+    private val eventService: EventService by inject(FX.defaultScope)
 
     fun list(event: Event): List<Run> = db.list(
-            RunDbEntity::eventId to EventDbEntityMapper.toDbEntity(event).id
+            RunDbEntity::eventId to eventService.mapper.toDbEntity(event).id
     ).map { RunDbEntityMapper.toUiEntity(event = event, dbEntity = it) as Run }
 
     fun save(run: Run) {
@@ -28,7 +29,7 @@ class RunService : Controller() {
     }
 
     fun watchList(event: Event): Observable<EntityWatchEvent<Run>> {
-        return db.watchListing(RunDbEntity::eventId to EventDbEntityMapper.toDbEntity(event).id)
+        return db.watchListing(RunDbEntity::eventId to eventService.mapper.toDbEntity(event).id)
                 .subscribeOn(Schedulers.io())
                 .map { EntityWatchEvent(
                         watchEvent = it.watchEvent,
@@ -38,7 +39,7 @@ class RunService : Controller() {
     }
 
     fun addTimeToFirstRunInSequenceWithoutRawTime(event: Event, time: BigDecimal) {
-        val eventDbEntity = EventDbEntityMapper.toDbEntity(event)
+        val eventDbEntity = eventService.mapper.toDbEntity(event)
         val firstRunInSequenceWithoutTimeOptional = db.list(
                 RunDbEntity::eventId to eventDbEntity.id
         ).parallelStream()

--- a/src/main/kotlin/org/coner/drs/io/service/ClassDefinitionService.kt
+++ b/src/main/kotlin/org/coner/drs/io/service/ClassDefinitionService.kt
@@ -1,0 +1,16 @@
+package org.coner.drs.io.service
+
+import org.coner.drs.Event
+import org.coner.drs.io.crispyfish.buildEventControlFile
+import tornadofx.*
+
+class ClassDefinitionService : Controller() {
+
+    fun listCategories(event: Event): List<String> {
+        return event.buildEventControlFile().queryCategories().map { it.abbreviation }
+    }
+
+    fun listHandicaps(event: Event): List<String> {
+        return event.buildEventControlFile().queryHandicaps().map { it.abbreviation }
+    }
+}

--- a/src/main/kotlin/org/coner/drs/io/service/EventService.kt
+++ b/src/main/kotlin/org/coner/drs/io/service/EventService.kt
@@ -1,14 +1,19 @@
-package org.coner.drs.io.db.service
+package org.coner.drs.io.service
 
 import io.reactivex.Observable
 import io.reactivex.schedulers.Schedulers
+import org.coner.crispyfish.filetype.classdefinition.ClassDefinitionFile
+import org.coner.crispyfish.filetype.ecf.EventControlFile
 import org.coner.drs.Event
+import org.coner.drs.Registration
 import org.coner.drs.io.DrsIoController
+import org.coner.drs.io.crispyfish.RegistrationMapper
 import org.coner.drs.io.db.EntityWatchEvent
 import org.coner.drs.io.db.entity.EventDbEntity
 import org.coner.drs.io.db.entity.EventDbEntityMapper
 import org.coner.snoozle.db.jvm.watchListing
 import tornadofx.*
+import java.io.File
 
 class EventService : Controller() {
 
@@ -16,8 +21,9 @@ class EventService : Controller() {
     private val db = io.model.db!!
     val mapper by lazy { EventDbEntityMapper(io.model.pathToCrispyFishDatabase!!) }
 
-    fun list(): List<Event> = db.list<EventDbEntity>()
-            .map { mapper.toUiEntity(it) as Event }
+    fun list(): List<Event> {
+        return db.list<EventDbEntity>().map { mapper.toUiEntity(it)!! }
+    }
 
     fun save(event: Event) {
         db.put(mapper.toDbEntity(event))
@@ -30,4 +36,6 @@ class EventService : Controller() {
                     id = it.id,
                     entity = mapper.toUiEntity(it.entity)
             ) }
+
 }
+

--- a/src/main/kotlin/org/coner/drs/io/service/RegistrationService.kt
+++ b/src/main/kotlin/org/coner/drs/io/service/RegistrationService.kt
@@ -1,11 +1,16 @@
 package org.coner.drs.io.service
 
+import de.helmbold.rxfilewatcher.PathObservables
+import io.reactivex.Observable
 import io.reactivex.Single
 import org.coner.drs.Event
 import org.coner.drs.Registration
 import org.coner.drs.io.crispyfish.RegistrationMapper
 import org.coner.drs.io.crispyfish.buildEventControlFile
+import org.coner.drs.io.db.EntityWatchEvent
 import tornadofx.*
+import java.nio.file.Path
+import java.nio.file.WatchEvent
 
 class RegistrationService : Controller() {
 
@@ -13,5 +18,17 @@ class RegistrationService : Controller() {
         event.buildEventControlFile()
                 .queryRegistrations()
                 .map { RegistrationMapper.toUiEntity(it) }
+    }
+
+    fun watchList(event: Event): Observable<List<Registration>> {
+        return PathObservables.watchNonRecursive(
+                event.buildEventControlFile().file.parentFile.toPath()
+        )
+                .filter {
+                    val watchedEventFileName = (it.context() as Path).toFile().name
+                    val registrationFileName = event.buildEventControlFile().registrationFile().file.name
+                    watchedEventFileName == registrationFileName
+                }
+                .map { list(event).blockingGet() }
     }
 }

--- a/src/main/kotlin/org/coner/drs/io/service/RegistrationService.kt
+++ b/src/main/kotlin/org/coner/drs/io/service/RegistrationService.kt
@@ -1,0 +1,16 @@
+package org.coner.drs.io.service
+
+import org.coner.drs.Event
+import org.coner.drs.Registration
+import org.coner.drs.io.crispyfish.RegistrationMapper
+import org.coner.drs.io.crispyfish.buildEventControlFile
+import tornadofx.*
+
+class RegistrationService : Controller() {
+
+    fun list(event: Event): List<Registration> {
+        return event.buildEventControlFile()
+                .queryRegistrations()
+                .map { RegistrationMapper.toUiEntity(it) }
+    }
+}

--- a/src/main/kotlin/org/coner/drs/io/service/RegistrationService.kt
+++ b/src/main/kotlin/org/coner/drs/io/service/RegistrationService.kt
@@ -1,5 +1,6 @@
 package org.coner.drs.io.service
 
+import io.reactivex.Single
 import org.coner.drs.Event
 import org.coner.drs.Registration
 import org.coner.drs.io.crispyfish.RegistrationMapper
@@ -8,8 +9,8 @@ import tornadofx.*
 
 class RegistrationService : Controller() {
 
-    fun list(event: Event): List<Registration> {
-        return event.buildEventControlFile()
+    fun list(event: Event): Single<List<Registration>> = Single.fromCallable {
+        event.buildEventControlFile()
                 .queryRegistrations()
                 .map { RegistrationMapper.toUiEntity(it) }
     }

--- a/src/main/kotlin/org/coner/drs/io/service/RunService.kt
+++ b/src/main/kotlin/org/coner/drs/io/service/RunService.kt
@@ -1,8 +1,10 @@
 package org.coner.drs.io.service
 
 import io. reactivex.Observable
+import io.reactivex.Single
 import io.reactivex.schedulers.Schedulers
 import org.coner.drs.Event
+import org.coner.drs.Registration
 import org.coner.drs.Run
 import org.coner.drs.io.DrsIoController
 import org.coner.drs.io.db.EntityWatchEvent
@@ -19,21 +21,25 @@ class RunService : Controller() {
     private val db = io.model.db!!
     private val eventService: EventService by inject(FX.defaultScope)
 
-    fun list(event: Event): List<Run> = db.list(
+    fun list(event: Event): Single<List<Run>> = Single.fromCallable { db.list(
             RunDbEntity::eventId to eventService.mapper.toDbEntity(event).id
-    ).map { RunDbEntityMapper.toUiEntity(event = event, dbEntity = it) as Run }
+    ).map {
+        RunDbEntityMapper.toUiEntity(event = event, dbEntity = it) as Run
+    } }
 
     fun save(run: Run) {
         db.put(RunDbEntityMapper.toDbEntity(run))
     }
 
-    fun watchList(event: Event): Observable<EntityWatchEvent<Run>> {
+    fun watchList(event: Event, registrations: List<Registration>): Observable<EntityWatchEvent<Run>> {
         return db.watchListing(RunDbEntity::eventId to eventService.mapper.toDbEntity(event).id)
                 .subscribeOn(Schedulers.io())
                 .map { EntityWatchEvent(
                         watchEvent = it.watchEvent,
                         id = it.id,
-                        entity = RunDbEntityMapper.toUiEntity(event, it.entity)
+                        entity = RunDbEntityMapper.toUiEntity(event, it.entity).apply {
+                            if (this != null) hydrateWithRegistrationMetadata(this, registrations)
+                        }
                 ) }
     }
 
@@ -86,6 +92,29 @@ class RunService : Controller() {
                         number = addNextDriverDbEntity.number
                 )
         db.put(runDbEntity)
+    }
+
+    fun hydrateWithRegistrationMetadata(runs: List<Run>, registrations: List<Registration>) {
+        for (run in runs) {
+            hydrateWithRegistrationMetadata(run, registrations)
+        }
+    }
+
+    fun hydrateWithRegistrationMetadata(run: Run, registrations: List<Registration>, destructive: Boolean = false) {
+        val category = run.registrationCategory
+        val handicap = run.registrationHandicap
+        val number = run.registrationNumber
+        if (category == null || handicap == null || number == null) return
+        val hydratedRegistration = registrations.firstOrNull {
+            it.category == category
+            && it.handicap == handicap
+            && it.number == number
+        }
+        run.registration = when {
+            hydratedRegistration != null -> hydratedRegistration
+            destructive -> Registration(category = category, handicap = handicap, number = number)
+            else -> return
+        }
     }
 
 }

--- a/src/main/kotlin/org/coner/drs/io/service/RunService.kt
+++ b/src/main/kotlin/org/coner/drs/io/service/RunService.kt
@@ -94,9 +94,9 @@ class RunService : Controller() {
         db.put(runDbEntity)
     }
 
-    fun hydrateWithRegistrationMetadata(runs: List<Run>, registrations: List<Registration>) {
+    fun hydrateWithRegistrationMetadata(runs: List<Run>, registrations: List<Registration>, destructive: Boolean = false) {
         for (run in runs) {
-            hydrateWithRegistrationMetadata(run, registrations)
+            hydrateWithRegistrationMetadata(run, registrations, destructive)
         }
     }
 

--- a/src/main/kotlin/org/coner/drs/io/service/RunService.kt
+++ b/src/main/kotlin/org/coner/drs/io/service/RunService.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.io.db.service
+package org.coner.drs.io.service
 
 import io. reactivex.Observable
 import io.reactivex.schedulers.Schedulers
@@ -7,7 +7,6 @@ import org.coner.drs.Run
 import org.coner.drs.io.DrsIoController
 import org.coner.drs.io.db.EntityWatchEvent
 import org.coner.drs.io.db.entity.EventDbEntity
-import org.coner.drs.io.db.entity.EventDbEntityMapper
 import org.coner.drs.io.db.entity.RunDbEntity
 import org.coner.drs.io.db.entity.RunDbEntityMapper
 import org.coner.snoozle.db.jvm.watchListing

--- a/src/main/kotlin/org/coner/drs/ui/addevent/AddEventCrispyFishMetadataStep.kt
+++ b/src/main/kotlin/org/coner/drs/ui/addevent/AddEventCrispyFishMetadataStep.kt
@@ -1,0 +1,127 @@
+package org.coner.drs.ui.addevent
+
+import javafx.beans.binding.StringBinding
+import javafx.beans.value.ObservableValue
+import javafx.stage.FileChooser
+import org.coner.drs.Event
+import org.coner.drs.EventModel
+import org.coner.drs.io.service.EventService
+import tornadofx.*
+import java.io.File
+
+class AddEventCrispyFishMetadataStepFragment : Fragment("Crispy Fish Metadata") {
+    val event: EventModel by inject()
+    val controller: CreateEventCrispyFishMetadataStepController by inject()
+    val eventService: EventService by inject()
+
+    override val root = form {
+        fieldset(title) {
+            field("Event Control File") {
+                textfield(bindRelativePathToCrispyFishFile(event.crispyFishMetadata.value.eventControlFileProperty)) {
+                    isEditable = false
+                    validator(
+                            control = this,
+                            property = event.crispyFishMetadata,
+                            trigger = ValidationTrigger.OnChange()
+                    ) {
+                        when {
+                            it == null -> error("Field is required")
+                            !eventService.io.isInsideCrispyFishDatabase(
+                                    event.crispyFishMetadata.value.eventControlFile
+                            ) -> {
+                                error("File must be inside Crispy Fish Database")
+                            }
+                            else -> null
+                        }
+                    }
+                }
+                button("Choose") {
+                    action { controller.onClickChooseEventControlFile() }
+                }
+            }
+            field("Class Definitions File") {
+                textfield(bindRelativePathToCrispyFishFile(event.crispyFishMetadata.value.classDefinitionFileProperty)) {
+                    isEditable = false
+                    validator(
+                        control = this,
+                        property = event.crispyFishMetadata,
+                        trigger = ValidationTrigger.OnChange()
+                    ) {
+                        when {
+                            it == null -> error("Field is required")
+                            !eventService.io.isInsideCrispyFishDatabase(
+                                    event.crispyFishMetadata.value.classDefinitionFile
+                            ) -> {
+                                error("File must be inside Crispy Fish Database")
+                            }
+                            else -> null
+                        }
+                    }
+                }
+                button("Choose") {
+                    action { controller.onClickChooseClassDefinitionsFile() }
+                }
+            }
+        }
+    }
+
+    fun bindRelativePathToCrispyFishFile(fileValue: ObservableValue<File>): StringBinding {
+        return fileValue.stringBinding {
+            try {
+                it?.toRelativeString(eventService.io.model.pathToCrispyFishDatabase!!)
+            } catch (e: Throwable) {
+                ""
+            }
+        }
+    }
+
+    override val complete = event.valid(
+            event.crispyFishMetadata // TODO: find out if/why this isn't updating
+    )
+}
+
+class CreateEventCrispyFishMetadataStepController : Controller() {
+    val event: EventModel by inject()
+    val eventService: EventService by inject()
+
+    fun onClickChooseEventControlFile() {
+        val crispyFishDatabase = eventService.io.model.pathToCrispyFishDatabase!!
+        val file = chooseFile(
+                title = "Choose Event Control File",
+                filters = arrayOf(FileChooser.ExtensionFilter(
+                        "Crispy Fish Event Control File", "*.ecf"
+                )),
+                owner = FX.primaryStage.owner,
+                mode = FileChooserMode.Single
+        ) {
+            val currentFile = event.crispyFishMetadata.value.eventControlFile
+            initialDirectory = if (currentFile?.startsWith(crispyFishDatabase) == true)
+                currentFile.parentFile
+            else
+                crispyFishDatabase
+        }.firstOrNull() ?: return
+        event.crispyFishMetadata.value.eventControlFile = file
+        event.validate(fields = *arrayOf(event.crispyFishMetadata))
+    }
+
+    fun onClickChooseClassDefinitionsFile() {
+        val crispyFishDatabase = eventService.io.model.pathToCrispyFishDatabase!!
+        val file = chooseFile(
+                title = "Choose Crispy Fish Class Definitions File",
+                filters = arrayOf(FileChooser.ExtensionFilter(
+                        "Crispy Fish Class Definitions", "*.def"
+                )),
+                owner = FX.primaryStage.owner,
+                mode = FileChooserMode.Single
+        ) {
+            val currentFile = event.crispyFishMetadata.value.classDefinitionFile
+            initialDirectory = if (currentFile?.startsWith(crispyFishDatabase) == true)
+                currentFile.parentFile
+            else
+                crispyFishDatabase
+        }.firstOrNull() ?: return
+        event.crispyFishMetadata.value.classDefinitionFile = file
+        event.validate(fields = *arrayOf(event.crispyFishMetadata))
+    }
+
+}

--- a/src/main/kotlin/org/coner/drs/ui/addevent/AddEventGeneralInformationStep.kt
+++ b/src/main/kotlin/org/coner/drs/ui/addevent/AddEventGeneralInformationStep.kt
@@ -1,0 +1,27 @@
+package org.coner.drs.ui.addevent
+
+import org.coner.drs.EventModel
+import org.coner.drs.io.DrsIoController
+import tornadofx.*
+
+class AddEventGeneralInformationStepFragment : Fragment("General Information") {
+    val event: EventModel by inject()
+    val io: DrsIoController by inject()
+
+    override val root = form {
+        fieldset(title) {
+            field("Date") {
+                datepicker(event.date) {
+                    required()
+                }
+            }
+            field("Name") {
+                textfield(event.name) {
+                    required()
+                }
+            }
+        }
+    }
+
+    override val complete = event.valid(event.date, event.name)
+}

--- a/src/main/kotlin/org/coner/drs/ui/addevent/AddEventWizard.kt
+++ b/src/main/kotlin/org/coner/drs/ui/addevent/AddEventWizard.kt
@@ -1,6 +1,7 @@
 package org.coner.drs.ui.addevent
 
 import org.coner.drs.EventModel
+import org.coner.drs.io.DrsIoController
 import org.coner.drs.io.service.EventService
 import tornadofx.*
 
@@ -22,7 +23,8 @@ class AddEventWizard : Wizard(
     override val canGoNext = currentPageComplete
 
     class Scope(source: tornadofx.Scope) : tornadofx.Scope(
-            FX.find<EventService>(source)
+            FX.find<EventService>(source),
+            FX.find<DrsIoController>(source)
     )
 }
 

--- a/src/main/kotlin/org/coner/drs/ui/addevent/AddEventWizard.kt
+++ b/src/main/kotlin/org/coner/drs/ui/addevent/AddEventWizard.kt
@@ -1,0 +1,28 @@
+package org.coner.drs.ui.addevent
+
+import org.coner.drs.EventModel
+import org.coner.drs.io.service.EventService
+import tornadofx.*
+
+class AddEventWizard : Wizard(
+        title = "Add Event",
+        heading = "Provide event information"
+) {
+    override val scope = super.scope as Scope
+
+    val event: EventModel by inject()
+
+    init {
+        graphic = resources.imageview("/coner-icon/coner-icon_64.png")
+        add<AddEventGeneralInformationStepFragment>()
+        add<AddEventCrispyFishMetadataStepFragment>()
+    }
+
+    override val canFinish = allPagesComplete
+    override val canGoNext = currentPageComplete
+
+    class Scope(source: tornadofx.Scope) : tornadofx.Scope(
+            FX.find<EventService>(source)
+    )
+}
+

--- a/src/main/kotlin/org/coner/drs/ui/choose_event/ChooseEventController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/choose_event/ChooseEventController.kt
@@ -1,6 +1,7 @@
 package org.coner.drs.ui.choose_event
 
 import com.github.thomasnield.rxkotlinfx.observeOnFx
+import org.coner.crispyfish.filetype.ecf.EventControlFile
 import org.coner.drs.Event
 import org.coner.drs.io.db.entityWatchEventConsumer
 import org.coner.drs.io.db.service.EventService
@@ -27,11 +28,7 @@ class ChooseEventController : Controller() {
     }
 
     fun addEvent() {
-        val event = Event(
-                date = LocalDate.now(),
-                name = "New Event"
-        )
-        service.save(event)
+        // TODO: wizard
     }
 
     fun save(event: Event) {

--- a/src/main/kotlin/org/coner/drs/ui/choose_event/ChooseEventController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/choose_event/ChooseEventController.kt
@@ -1,14 +1,13 @@
 package org.coner.drs.ui.choose_event
 
 import com.github.thomasnield.rxkotlinfx.observeOnFx
-import org.coner.crispyfish.filetype.ecf.EventControlFile
 import org.coner.drs.Event
 import org.coner.drs.io.db.entityWatchEventConsumer
-import org.coner.drs.io.db.service.EventService
+import org.coner.drs.io.service.EventService
+import org.coner.drs.ui.addevent.AddEventWizard
 import org.coner.drs.ui.main.ChangeToScreenEvent
 import org.coner.drs.ui.main.Screen
 import tornadofx.*
-import java.time.LocalDate
 
 class ChooseEventController : Controller() {
     val model: ChooseEventModel by inject()
@@ -28,7 +27,11 @@ class ChooseEventController : Controller() {
     }
 
     fun addEvent() {
-        // TODO: wizard
+        val wizard = find<AddEventWizard>(AddEventWizard.Scope(scope))
+        wizard.onComplete {
+            service.save(wizard.event.item)
+        }
+        wizard.openModal()
     }
 
     fun save(event: Event) {

--- a/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventBottomView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventBottomView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.choose_event
+package org.coner.drs.ui.chooseevent
 
 import javafx.scene.layout.Priority
 import tornadofx.*

--- a/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventController.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.choose_event
+package org.coner.drs.ui.chooseevent
 
 import com.github.thomasnield.rxkotlinfx.observeOnFx
 import org.coner.drs.Event

--- a/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventModel.kt
+++ b/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventModel.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.choose_event
+package org.coner.drs.ui.chooseevent
 
 import io.reactivex.disposables.CompositeDisposable
 import javafx.beans.property.SimpleObjectProperty

--- a/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventTableView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventTableView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.choose_event
+package org.coner.drs.ui.chooseevent
 
 import org.coner.drs.Event
 import tornadofx.*

--- a/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/chooseevent/ChooseEventView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.choose_event
+package org.coner.drs.ui.chooseevent
 
 import tornadofx.*
 

--- a/src/main/kotlin/org/coner/drs/ui/main/MainController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/main/MainController.kt
@@ -3,7 +3,7 @@ package org.coner.drs.ui.main
 import org.coner.drs.io.DrsIoController
 import org.coner.drs.ui.runevent.RunEventFragment
 import org.coner.drs.ui.start.StartView
-import org.coner.drs.ui.choose_event.ChooseEventView
+import org.coner.drs.ui.chooseevent.ChooseEventView
 import tornadofx.*
 
 class MainController : Controller() {

--- a/src/main/kotlin/org/coner/drs/ui/main/MainController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/main/MainController.kt
@@ -1,7 +1,7 @@
 package org.coner.drs.ui.main
 
 import org.coner.drs.io.DrsIoController
-import org.coner.drs.ui.run_event.RunEventFragment
+import org.coner.drs.ui.runevent.RunEventFragment
 import org.coner.drs.ui.start.StartView
 import org.coner.drs.ui.choose_event.ChooseEventView
 import tornadofx.*

--- a/src/main/kotlin/org/coner/drs/ui/main/MainController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/main/MainController.kt
@@ -15,7 +15,10 @@ class MainController : Controller() {
             is Screen.Start -> find<StartView>()
             is Screen.ChooseEvent -> {
                 if (model.screen == Screen.Start) {
-                    drsIo.open(screen.dir)
+                    drsIo.open(
+                            pathToDrsDatabase = screen.pathToDrsDb,
+                            pathToCrispyFishDatabase = screen.pathToCfDb
+                    )
                 }
                 find<ChooseEventView>()
             }

--- a/src/main/kotlin/org/coner/drs/ui/main/Screen.kt
+++ b/src/main/kotlin/org/coner/drs/ui/main/Screen.kt
@@ -5,6 +5,6 @@ import java.io.File
 
 sealed class Screen {
     object Start : Screen()
-    class ChooseEvent(val dir: File) : Screen()
+    class ChooseEvent(val pathToDrsDb: File, val pathToCfDb: File) : Screen()
     class RunEvent(val event: Event) : Screen()
 }

--- a/src/main/kotlin/org/coner/drs/ui/run_event/AddNextDriverController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/run_event/AddNextDriverController.kt
@@ -1,7 +1,7 @@
 package org.coner.drs.ui.run_event
 
 import org.coner.drs.Run
-import org.coner.drs.io.db.service.RunService
+import org.coner.drs.io.service.RunService
 import org.coner.drs.util.levenshtein
 import tornadofx.*
 import kotlin.streams.toList

--- a/src/main/kotlin/org/coner/drs/ui/run_event/RunEventController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/run_event/RunEventController.kt
@@ -4,7 +4,7 @@ import com.github.thomasnield.rxkotlinfx.observeOnFx
 import org.coner.drs.Run
 import org.coner.drs.TimerConfiguration
 import org.coner.drs.io.db.entityWatchEventConsumer
-import org.coner.drs.io.db.service.RunService
+import org.coner.drs.io.service.RunService
 import org.coner.drs.io.timer.TimerService
 import org.coner.timer.model.FinishTriggerElapsedTimeOnly
 import org.coner.timer.output.TimerOutputWriter

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverController.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import org.coner.drs.Run
 import org.coner.drs.io.service.RunService

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverController.kt
@@ -1,5 +1,7 @@
 package org.coner.drs.ui.runevent
 
+import com.github.thomasnield.rxkotlinfx.observeOnFx
+import com.github.thomasnield.rxkotlinfx.onChangedObservable
 import javafx.collections.SetChangeListener
 import org.coner.drs.Registration
 import org.coner.drs.Run
@@ -7,6 +9,7 @@ import org.coner.drs.io.service.RegistrationService
 import org.coner.drs.io.service.RunService
 import org.coner.drs.util.levenshtein
 import tornadofx.*
+import java.util.concurrent.TimeUnit
 import kotlin.streams.toList
 
 class AddNextDriverController : Controller() {
@@ -17,9 +20,10 @@ class AddNextDriverController : Controller() {
 
     init {
         runEventModel.registrations.onChange { buildRegistrationHints() }
-        model.registrationHints.addListener { change: SetChangeListener.Change<out RegistrationHint>? ->
-            buildRegistrationHintsToRegistrationsMap()
-        }
+        model.registrationHints.onChangedObservable()
+                .observeOnFx()
+                .debounce(100, TimeUnit.MILLISECONDS)
+                .subscribe { buildRegistrationHintsToRegistrationsMap() }
         model.driverAutoCompleteOrderPreferenceProperty.addListener { observable, old, new ->
             reformatNumbersField(old, new)
         }

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverController.kt
@@ -13,7 +13,7 @@ class AddNextDriverController : Controller() {
     val runService: RunService by inject()
 
     init {
-        runEventModel.runs.onChange { buildRegistrationHints() }
+        runEventModel.registrations.onChange { buildRegistrationHints() }
         model.driverAutoCompleteOrderPreferenceProperty.addListener { observable, old, new ->
             reformatNumbersField(old, new)
         }
@@ -55,9 +55,9 @@ class AddNextDriverController : Controller() {
     }
 
     fun buildRegistrationHints() {
-        val runs = synchronized(runEventModel.runs) { runEventModel.runs.toList() }
+        val registrations = synchronized(runEventModel.registrations) { runEventModel.registrations.toList() }
         runAsync {
-            runs.parallelStream()
+            registrations.parallelStream()
                     .map {
                         RegistrationHint(
                                 category = it.category,

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverController.kt
@@ -47,7 +47,11 @@ class AddNextDriverController : Controller() {
             sequenceProperty.bind(integerBinding(runEventModel.runs) {
                 val runs = synchronized(runEventModel.runs) { runEventModel.runs.toList() }
                 val firstRunWithoutDriver = runs.parallelStream()
-                        .filter { it.category.isBlank() && it.handicap.isBlank() && it.number.isBlank() }
+                        .filter {
+                            it.registrationCategory.isBlank()
+                                    && it.registrationHandicap.isBlank()
+                                    && it.registrationNumber.isBlank()
+                        }
                         .sorted(compareBy(Run::sequence))
                         .findFirst().orElse(null)
                 if (firstRunWithoutDriver == null) {
@@ -66,10 +70,7 @@ class AddNextDriverController : Controller() {
             val sequence = it.sequence
             it.sequenceProperty.unbind()
             it.sequence = sequence
-            val nextDriverNumbers = model.driverAutoCompleteOrderPreference.stringConverter.fromString(model.numbersField)
-            it.number = nextDriverNumbers.number
-            it.category = nextDriverNumbers.category
-            it.handicap = nextDriverNumbers.handicap
+            it.registration = model.registrationForNumbers
             it
         }
         model.nextDriver.commit()

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverModel.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverModel.kt
@@ -4,7 +4,10 @@ import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
 import javafx.collections.FXCollections
 import org.coner.drs.NextDriverModel
+import org.coner.drs.Registration
 import tornadofx.*
+import tornadofx.getValue
+import tornadofx.setValue
 
 class AddNextDriverModel : ViewModel() {
 
@@ -13,6 +16,9 @@ class AddNextDriverModel : ViewModel() {
 
     val numbersFieldProperty = SimpleStringProperty(this, "numbers", "")
     var numbersField by numbersFieldProperty
+
+    val registrationForNumbersProperty = SimpleObjectProperty<Registration>(this, "registration")
+    var registrationForNumbers by registrationForNumbersProperty
 
     val driverAutoCompleteOrderPreferenceProperty = SimpleObjectProperty<DriverAutoCompleteOrderPreference>(
             this,
@@ -25,4 +31,5 @@ class AddNextDriverModel : ViewModel() {
             DriverAutoCompleteOrderPreference.NumberCategoryHandicap,
             DriverAutoCompleteOrderPreference.CategoryHandicapNumber
     )
+    val registrationHintsToRegistrations = FXCollections.observableHashMap<RegistrationHint, Registration>()
 }

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverModel.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverModel.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverView.kt
@@ -12,11 +12,6 @@ class AddNextDriverView : View("Add Next Driver") {
     private val model: AddNextDriverModel by inject()
     private val controller: AddNextDriverController by inject()
 
-    private lateinit var numberTextField: TextField
-    private lateinit var categoryTextField: TextField
-    private lateinit var handicapTextField: TextField
-    private lateinit var addButton: Button
-
     override val root = form {
         fieldset(text = title, labelPosition = Orientation.VERTICAL) {
             hgrow = Priority.NEVER
@@ -28,7 +23,6 @@ class AddNextDriverView : View("Add Next Driver") {
             }
             field(text = "Numbers") {
                 textfield(model.numbersFieldProperty) {
-                    numberTextField = this
                     required()
                     bindAutoCompletion(suggestionsProvider = { controller.buildNumbersHints() }) {
                         setDelay(0)
@@ -42,7 +36,6 @@ class AddNextDriverView : View("Add Next Driver") {
             }
             buttonbar {
                 button("Add") {
-                    addButton = this
                     enableWhen { model.nextDriver.valid }
                     action { controller.addNextDriver() }
                     tooltip("Shortcut: Ctrl+Enter")

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.geometry.Orientation
 import javafx.scene.control.Button

--- a/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/AddNextDriverView.kt
@@ -48,6 +48,25 @@ class AddNextDriverView : View("Add Next Driver") {
                 }
             }
         }
+        fieldset("Identity", labelPosition = Orientation.VERTICAL) {
+            field("Name") {
+                textfield(model.registrationForNumbersProperty.select { it.nameProperty }) {
+                    isEditable = false
+                }
+            }
+        }
+        fieldset("Car", labelPosition = Orientation.VERTICAL) {
+            field("Model") {
+                textfield(model.registrationForNumbersProperty.select { it.carModelProperty }) {
+                    isEditable = false
+                }
+            }
+            field("Color") {
+                textfield(model.registrationForNumbersProperty.select { it.carColorProperty }) {
+                    isEditable = false
+                }
+            }
+        }
         pane {
             vgrow = Priority.ALWAYS
         }

--- a/src/main/kotlin/org/coner/drs/ui/runevent/DriverAutoCompleteOrderPreference.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/DriverAutoCompleteOrderPreference.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.util.StringConverter
 

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RegistrationHint.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RegistrationHint.kt
@@ -1,3 +1,3 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 data class RegistrationHint(val category: String, val handicap: String, val number: String)

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventController.kt
@@ -56,12 +56,21 @@ class RunEventController : Controller() {
     }
 
     fun docked() {
-        model.disposables.add(runService.watchList(model.event, model.registrations)
-                .observeOnFx()
-                .subscribe(entityWatchEventConsumer(
-                        idProperty = Run::id,
-                        list = model.runs
-                ))
+        model.disposables.addAll(
+                runService.watchList(model.event, model.registrations)
+                    .subscribeOn(Schedulers.io())
+                    .observeOnFx()
+                    .subscribe(entityWatchEventConsumer(
+                            idProperty = Run::id,
+                            list = model.runs
+                    )),
+                registrationService.watchList(model.event)
+                        .subscribeOn(Schedulers.io())
+                        .observeOnFx()
+                        .subscribe {
+                            model.registrations.setAll(it)
+                            runService.hydrateWithRegistrationMetadata(model.runs, it, true)
+                        }
         )
     }
 

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventController.kt
@@ -4,6 +4,7 @@ import com.github.thomasnield.rxkotlinfx.observeOnFx
 import org.coner.drs.Run
 import org.coner.drs.TimerConfiguration
 import org.coner.drs.io.db.entityWatchEventConsumer
+import org.coner.drs.io.service.RegistrationService
 import org.coner.drs.io.service.RunService
 import org.coner.drs.io.timer.TimerService
 import org.coner.timer.model.FinishTriggerElapsedTimeOnly
@@ -12,12 +13,14 @@ import tornadofx.*
 
 class RunEventController : Controller() {
     val model: RunEventModel by inject()
+    val registrationService: RegistrationService by inject()
     val runService: RunService by inject()
     val timerService: TimerService by inject()
 
     fun init() {
         runService.io.createDrsDbRunsPath(model.event)
         loadRuns()
+        loadRegistrations()
     }
 
     fun loadRuns() {
@@ -26,6 +29,15 @@ class RunEventController : Controller() {
         } success {
             model.runs.clear()
             model.runs.addAll(it)
+        }
+    }
+
+    fun loadRegistrations() {
+        runAsync {
+            registrationService.list(model.event)
+        } ui {
+            model.registrations.clear()
+            model.registrations.addAll(it)
         }
     }
 

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventController.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import com.github.thomasnield.rxkotlinfx.observeOnFx
 import org.coner.drs.Run

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventController.kt
@@ -18,7 +18,6 @@ class RunEventController : Controller() {
     val timerService: TimerService by inject()
 
     fun init() {
-        runService.io.createDrsDbRunsPath(model.event)
         loadRuns()
         loadRegistrations()
     }

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventFragment.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventFragment.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.scene.layout.Priority
 import javafx.scene.layout.Region

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventLeftDrawerView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventLeftDrawerView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.geometry.Side
 import tornadofx.*

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventModel.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventModel.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import io.reactivex.disposables.CompositeDisposable
 import javafx.beans.property.SimpleObjectProperty

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventModel.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventModel.kt
@@ -4,14 +4,17 @@ import io.reactivex.disposables.CompositeDisposable
 import javafx.beans.property.SimpleObjectProperty
 import javafx.beans.property.SimpleStringProperty
 import org.coner.drs.Event
+import org.coner.drs.Registration
 import org.coner.drs.Run
 import org.coner.drs.TimerConfiguration
 import tornadofx.*
 
 class RunEventModel : ViewModel() {
     val runs = observableList<Run>()
+    val registrations = observableList<Registration>()
     val eventProperty = SimpleObjectProperty<Event>()
     var event by eventProperty
+
     val disposables = CompositeDisposable()
 
     val controlTextProperty = SimpleStringProperty(this, "controlText")

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventRightDrawerView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventRightDrawerView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.geometry.Side
 import tornadofx.*

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventTableView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventTableView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.collections.transformation.SortedList
 import javafx.scene.layout.Priority

--- a/src/main/kotlin/org/coner/drs/ui/runevent/RunEventTableView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/RunEventTableView.kt
@@ -14,20 +14,18 @@ class RunEventTableView : View() {
         setSortPolicy { false }
         vgrow = Priority.ALWAYS
         readonlyColumn("Sequence", Run::sequence)
-        column("Category", Run::categoryProperty) {
-            makeEditable()
+        column("Category", Run::registrationCategoryProperty) {
         }
-        column("Handicap", Run::handicapProperty) {
-            makeEditable()
+        column("Handicap", Run::registrationHandicapProperty) {
         }
-        column("Number", Run::numberProperty) {
-            makeEditable()
+        column("Number", Run::registrationNumberProperty) {
         }
+        column("Name", Run::registrationDriverNameProperty)
+        column("Car Model", Run::registrationCarModelProperty)
+        column("Car Color", Run::registrationCarColorProperty)
         column("Time", Run::rawTime) {
-            makeEditable()
         }
         column("Cones", Run::conesProperty) {
-            makeEditable()
         }
         column("+/-", Run::conesProperty).cellFormat {
             graphic = hbox {

--- a/src/main/kotlin/org/coner/drs/ui/runevent/TimerConfigurationModel.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/TimerConfigurationModel.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.beans.property.SimpleStringProperty
 import org.coner.drs.TimerConfiguration

--- a/src/main/kotlin/org/coner/drs/ui/runevent/TimerConfigurationView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/TimerConfigurationView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.scene.control.ButtonBar
 import org.coner.drs.TimerConfiguration

--- a/src/main/kotlin/org/coner/drs/ui/runevent/TimerView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/runevent/TimerView.kt
@@ -1,4 +1,4 @@
-package org.coner.drs.ui.run_event
+package org.coner.drs.ui.runevent
 
 import javafx.geometry.Orientation
 import javafx.stage.Modality

--- a/src/main/kotlin/org/coner/drs/ui/start/StartController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/start/StartController.kt
@@ -8,11 +8,19 @@ class StartController : Controller() {
     val model: StartModel by inject()
 
     fun onClickChooseRawSheetDatabase() {
-        val dir = chooseDirectory("Raw Sheet Database") ?: return
+        val dir = chooseDirectory("Coner Digital Raw Sheet Database") ?: return
         model.rawSheetDatabase = dir
     }
 
+    fun onClickChooseCrispyFishDatabase() {
+        val dir = chooseDirectory("Crispy Fish Database") ?: return
+        model.crispyFishDatabase = dir
+    }
+
     fun onClickStart() {
-        fire(ChangeToScreenEvent(Screen.ChooseEvent(model.rawSheetDatabase)))
+        fire(ChangeToScreenEvent(Screen.ChooseEvent(
+                pathToDrsDb = model.rawSheetDatabase,
+                pathToCfDb = model.crispyFishDatabase
+        )))
     }
 }

--- a/src/main/kotlin/org/coner/drs/ui/start/StartController.kt
+++ b/src/main/kotlin/org/coner/drs/ui/start/StartController.kt
@@ -3,6 +3,7 @@ package org.coner.drs.ui.start
 import org.coner.drs.ui.main.ChangeToScreenEvent
 import org.coner.drs.ui.main.Screen
 import tornadofx.*
+import java.io.File
 
 class StartController : Controller() {
     val model: StartModel by inject()
@@ -18,9 +19,13 @@ class StartController : Controller() {
     }
 
     fun onClickStart() {
-        fire(ChangeToScreenEvent(Screen.ChooseEvent(
-                pathToDrsDb = model.rawSheetDatabase,
-                pathToCfDb = model.crispyFishDatabase
-        )))
+        model.commit {
+            fire(ChangeToScreenEvent(Screen.ChooseEvent(
+                    pathToDrsDb = model.rawSheetDatabase,
+                    pathToCfDb = model.crispyFishDatabase
+            )))
+        }
     }
+
+
 }

--- a/src/main/kotlin/org/coner/drs/ui/start/StartModel.kt
+++ b/src/main/kotlin/org/coner/drs/ui/start/StartModel.kt
@@ -7,9 +7,24 @@ import tornadofx.getValue
 import tornadofx.setValue
 
 class StartModel : ViewModel() {
-    val rawSheetDatabaseProperty = SimpleObjectProperty<File>(this, "rawSheetDatabase")
+    val rawSheetDatabaseProperty = SimpleObjectProperty<File>(
+            this,
+            "rawSheetDatabase",
+            with(config) { if (containsKey("rawSheetDatabase")) File(string("rawSheetDatabase")) else null }
+    )
     var rawSheetDatabase by rawSheetDatabaseProperty
-    val crispyFishDatabaseProperty = SimpleObjectProperty<File>(this, "crispyFishDatabase")
+    val crispyFishDatabaseProperty = SimpleObjectProperty<File>(
+            this,
+            "crispyFishDatabase",
+            with(config) { if (containsKey("crispyFishDatabase")) File(string("crispyFishDatabase")) else null }
+    )
     var crispyFishDatabase by crispyFishDatabaseProperty
 
+    override fun onCommit() {
+        with(config) {
+            set("rawSheetDatabase" to rawSheetDatabase.absolutePath)
+            set("crispyFishDatabase" to crispyFishDatabase.absolutePath)
+            save()
+        }
+    }
 }

--- a/src/main/kotlin/org/coner/drs/ui/start/StartModel.kt
+++ b/src/main/kotlin/org/coner/drs/ui/start/StartModel.kt
@@ -3,8 +3,13 @@ package org.coner.drs.ui.start
 import javafx.beans.property.SimpleObjectProperty
 import tornadofx.*
 import java.io.File
+import tornadofx.getValue
+import tornadofx.setValue
 
 class StartModel : ViewModel() {
     val rawSheetDatabaseProperty = SimpleObjectProperty<File>(this, "rawSheetDatabase")
     var rawSheetDatabase by rawSheetDatabaseProperty
+    val crispyFishDatabaseProperty = SimpleObjectProperty<File>(this, "crispyFishDatabase")
+    var crispyFishDatabase by crispyFishDatabaseProperty
+
 }

--- a/src/main/kotlin/org/coner/drs/ui/start/StartView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/start/StartView.kt
@@ -10,7 +10,9 @@ class StartView : View("Start") {
         form {
             fieldset("Databases") {
                 field("Coner Digital Raw Sheet") {
-                    text(model.rawSheetDatabaseProperty.stringBinding { it?.absolutePath ?: "" })
+                    textfield(model.rawSheetDatabaseProperty.stringBinding { it?.absolutePath ?: "" }) {
+                        isEditable = false
+                    }
                     button("Choose") {
                         action {
                             controller.onClickChooseRawSheetDatabase()
@@ -18,7 +20,9 @@ class StartView : View("Start") {
                     }
                 }
                 field("Crispy Fish") {
-                    text(model.crispyFishDatabaseProperty.stringBinding { it?.absolutePath ?: ""})
+                    textfield(model.crispyFishDatabaseProperty.stringBinding { it?.absolutePath ?: ""}) {
+                        isEditable = false
+                    }
                     button("Choose") {
                         action {
                             controller.onClickChooseCrispyFishDatabase()

--- a/src/main/kotlin/org/coner/drs/ui/start/StartView.kt
+++ b/src/main/kotlin/org/coner/drs/ui/start/StartView.kt
@@ -8,12 +8,20 @@ class StartView : View("Start") {
 
     override val root = stackpane {
         form {
-            fieldset("Paths") {
-                field("Raw Sheet Database") {
+            fieldset("Databases") {
+                field("Coner Digital Raw Sheet") {
                     text(model.rawSheetDatabaseProperty.stringBinding { it?.absolutePath ?: "" })
                     button("Choose") {
                         action {
                             controller.onClickChooseRawSheetDatabase()
+                        }
+                    }
+                }
+                field("Crispy Fish") {
+                    text(model.crispyFishDatabaseProperty.stringBinding { it?.absolutePath ?: ""})
+                    button("Choose") {
+                        action {
+                            controller.onClickChooseCrispyFishDatabase()
                         }
                     }
                 }

--- a/src/main/kotlin/org/coner/drs/util/CrispyFish.kt
+++ b/src/main/kotlin/org/coner/drs/util/CrispyFish.kt
@@ -1,0 +1,6 @@
+package org.coner.drs.util
+
+import org.coner.crispyfish.filetype.classdefinition.ClassDefinitionFile
+import org.coner.crispyfish.filetype.ecf.EventControlFile
+import org.coner.drs.Event
+

--- a/src/main/kotlin/org/coner/drs/util/CrispyFish.kt
+++ b/src/main/kotlin/org/coner/drs/util/CrispyFish.kt
@@ -1,6 +1,14 @@
 package org.coner.drs.util
 
-import org.coner.crispyfish.filetype.classdefinition.ClassDefinitionFile
-import org.coner.crispyfish.filetype.ecf.EventControlFile
-import org.coner.drs.Event
+import javafx.scene.control.TextInputControl
+import org.coner.drs.io.DrsIoController
+import tornadofx.*
+import java.io.File
 
+fun TextInputControl.requireFileWithinCrispyFishDatabase() = validator(ValidationTrigger.OnChange()) {
+    val io = find<DrsIoController>()
+    if (!io.isInsideCrispyFishDatabase(File(it)))
+        error("File must be inside Crispy Fish Database")
+    else
+        null
+}


### PR DESCRIPTION
[Crispy Fish](https://github.com/caeos/crispy-fish) is a library for consuming data from a popular commercial autocross timing application which shall not be named.

This initial integration uses Crispy Fish to source live registration data used for display:

- Add Next Driver form
  - Auto-fill suggestions for number/category/handicap
  - Driver name and car information displayed based on selection
- Runs table
  - Driver name and car information displayed on each row

In order to support these features, the app needs to know the path to the Crispy Fish database and the file for the event. In service of these requirements:

- The form displayed at startup requires the path to the Crispy Fish database
- Creating an event in the Digital Raw Sheet database now uses a wizard which helps find the path to the Crispy Fish event file

Additionally, the Run Event screen watches the Crispy Fish event's registration file for changes, and will automatically refresh the registration data if there are any (for example classing, numbers, car model, etc). By and large this works well and does a good job keeping the auto-fill suggestions and displayed driver data up to date. There are some corner cases associated with this, and so the following behaviors are expected:

- If a driver already has runs entered into the Digital Raw Sheet and subsequently their category, handicap, or numbers change, the Run Event table will display blank spaces in the name, car model, and car color columns. This is because the registration data no longer contains the category, handicap, and numbers combination entered earlier. If the raw sheet worker does not correct this, it can easily be caught and corrected during audit.
- If a worker is in the process of filling the Add Next Driver form and has already filled the category/handicap/numbers for a driver with registration data changing after the form is filled and its Add button pressed, the Run Event table will display blank spaces in the name, car model, and car color columns. This is because the registration data no longer contains the category, handicap, and numbers combination entered earlier. If the raw sheet worker does not correct this, it can easily be caught and corrected during audit.